### PR TITLE
fix: don't run pre-commit checks

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,3 +1,4 @@
 final: prev: {
   bazel-watcher = import ./development/tools/bazel-watcher.nix final prev;
+  pre-commit = import ./tools/misc/pre-commit.nix final prev;
 }

--- a/overlays/tools/misc/pre-commit.nix
+++ b/overlays/tools/misc/pre-commit.nix
@@ -1,0 +1,17 @@
+# pre-commit checkPhase depends on many toolchain that we
+# would not need otherwise, one being dotnet-sdk, which is
+# broken for Darwin on nixos-unstable.
+_final: prev:
+(prev.pre-commit.override {
+  dotnet-sdk = null;
+  cargo = null;
+  git = null;
+  go = null;
+  nodejs = null;
+})
+.overrideAttrs (_old: {
+  checkInputs = [];
+  doCheck = false;
+  doInstallCheck = false;
+  pythonImportCheck = [];
+})


### PR DESCRIPTION
This commit adds a new overlay for pre-commit, which removes
all the checkInputs and disables running its tests. This
removes many unnecessary toolchains from our build graph,
which some are broken on Darwin, e.g. dotnet-sdk.