### PR TITLE
fix: remove `flake.lock` in auto-update-flake workflow

### DIFF
--- a/.github/workflows/auto-merge-manager.yml
+++ b/.github/workflows/auto-merge-manager.yml
@@ -28,8 +28,9 @@ jobs:
 
     # We need to duplicate the base check here due to `pull_request_review`.
     if: >
-      (startsWith(github.event.pull_request.base.ref, 'main'))
-      && (github.event.action == 'ready_for_review' || !github.event.pull_request.draft)
+      (startsWith(github.event.pull_request.base.ref, 'main')) &&
+      (github.event.action == 'ready_for_review' ||
+      !github.event.pull_request.draft)
 
     steps:
       - name: Query Pull Request ID
@@ -50,7 +51,7 @@ jobs:
               }
             }
     outputs:
-      pr_id: ${{ fromJSON(steps.query_pr_id.outputs.data).repository.pullRequest.id }}
+      pr_id: ${{fromJSON(steps.query_pr_id.outputs.data).repository.pullRequest.id}}
 
   #
   # Disable Auto Merge

--- a/.github/workflows/auto-update-flakes.yml
+++ b/.github/workflows/auto-update-flakes.yml
@@ -2,7 +2,7 @@ name: Update Flake Inputs
 
 on:
   schedule:
-  - cron: "0 4 * * 1"
+    - cron: "0 4 * * 1"
 
 jobs:
   update-flakes:
@@ -10,18 +10,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2.4.0
-    - uses: cachix/install-nix-action@v15
-      with:
-        extra_nix_config: |
-          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-          trusted-binary-caches = https://cache.nixos.org
-          trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-    - run: "nix flake update"
-    - uses: actions/upload-artifact@v3
-      with:
-        name: flake-lock
-        path: flake.lock
+      - uses: actions/checkout@v2.4.0
+      - uses: cachix/install-nix-action@v15
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+            trusted-binary-caches = https://cache.nixos.org
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+      - run: "nix flake update"
+      - uses: actions/upload-artifact@v3
+        with:
+          name: flake-lock
+          path: flake.lock
 
   test-new-inputs:
     name: "Test new inputs"
@@ -32,18 +32,18 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2.4.0
-    - uses: cachix/install-nix-action@v15
-      with:
-        extra_nix_config: |
-          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-          trusted-binary-caches = https://cache.nixos.org
-          trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-    - uses: actions/download-artifact@v3
-      with:
-        name: flake-lock
-        path: flake.lock
-    - run: "nix flake check"
+      - uses: actions/checkout@v2.4.0
+      - uses: cachix/install-nix-action@v15
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+            trusted-binary-caches = https://cache.nixos.org
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+      - uses: actions/download-artifact@v3
+        with:
+          name: flake-lock
+          path: flake.lock
+      - run: "nix flake check"
 
   push-changes:
     name: "Push new inputs"
@@ -51,21 +51,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2.4.0
-    - uses: actions/download-artifact@v3
-      with:
-        name: flake-lock
-        path: flake.lock
-    - name: Commit changes
-      run: |
-        git config user.name "TerraMagna";
-        git config user.email "fides@terramagna.com.br";
+      - uses: actions/checkout@v2.4.0
+      - uses: actions/download-artifact@v3
+        with:
+          name: flake-lock
+          path: flake.lock
+      - name: Commit changes
+        run: |
+          git config user.name "TerraMagna";
+          git config user.email "fides@terramagna.com.br";
 
-        if git diff --quiet flake.lock; then
-          echo "No changes in flake.lock";
-        else
-          echo "Changes in flake.lock detected, commiting";
-          git add flake.lock;
-          git commit -m "chore(deps): $(date +%F) auto-update flake.lock";
-          git push
-        fi
+          if git diff --quiet flake.lock; then
+            echo "No changes in flake.lock";
+          else
+            echo "Changes in flake.lock detected, commiting";
+            git add flake.lock;
+            git commit -m "chore(deps): $(date +%F) auto-update flake.lock";
+            git push
+          fi

--- a/.github/workflows/auto-update-flakes.yml
+++ b/.github/workflows/auto-update-flakes.yml
@@ -39,6 +39,7 @@ jobs:
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
             trusted-binary-caches = https://cache.nixos.org
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+      - run: rm flake.lock
       - uses: actions/download-artifact@v3
         with:
           name: flake-lock
@@ -52,6 +53,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.4.0
+      - run: rm flake.lock
       - uses: actions/download-artifact@v3
         with:
           name: flake-lock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: Continous Integration
 on:
   pull_request:
     branches:
-    - main
+      - maim
   push:
     branches:
-    - main
+      - main
 
 jobs:
   flake-checks:
@@ -17,11 +17,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2.4.0
-    - uses: cachix/install-nix-action@v15
-      with:
-        extra_nix_config: |
-          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-          trusted-binary-caches = https://cache.nixos.org
-          trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-    - run: "nix flake check"
+      - uses: actions/checkout@v2.4.0
+      - uses: cachix/install-nix-action@v15
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+            trusted-binary-caches = https://cache.nixos.org
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+      - run: "nix flake check"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Continous Integration
 on:
   pull_request:
     branches:
-      - maim
+      - main
   push:
     branches:
       - main

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1654007547,
-        "narHash": "sha256-G812EeXZeGeGjkAvbTleGwcKFCGxdLOQb9aViOWASPc=",
+        "lastModified": 1660639432,
+        "narHash": "sha256-2WDiboOCfB0LhvnDVMXOAr8ZLDfm3WdO54CkoDPwN1A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5643714dea562f0161529ab23058562afeff46d0",
+        "rev": "6c6409e965a6c883677be7b9d87a95fab6c3472e",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1652714503,
-        "narHash": "sha256-qQKVEfDe5FqvGgkZtg5Pc491foeiDPIOeycHMqnPDps=",
+        "lastModified": 1659629599,
+        "narHash": "sha256-c9rvaqaH3HZo/C70E7rB18YSywa4ryTtN7CZ3cuCmoA=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "521a524771a8e93caddaa0ac1d67d03766a8b0b3",
+        "rev": "6a9402e8f233de16536349d1dd3f4595c23386a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Our current `auto-update-flake` workflow downloads the newest `flake.lock` file from the parent job, but since the file already exists (per checkout) it fails.

This PR fixes it by removing the `flake.lock` file before downloading the newest `flake.lock`.