### PR TITLE
chore: remove gcc from mkTmShell env

### DIFF
--- a/lib/shell.nix
+++ b/lib/shell.nix
@@ -19,55 +19,54 @@
     isLinux && (hasInfix "NixOS" issue);
 
   /*
-    *
-   * A custom `mkShell` implementation that has suppor for easily defining
-   * custom commands and creating bubblewrapped FHS environments.
-   *
-   * ## Bubblewrapping
-   *
-   * If the argument `bubblewrap` is set to `true`, the shell will be created
-   * inside a bubblewrapped FHS environment (i.e. using Nixpkgs'
-   * buildFHSUserEnvBubblewrap). If value is `false` (or not present), the
-   * shell is created using `mkShell`.
-   *
-   * Having a bubblewrapped shell is useful if a dependency of the project
-   * needs some native dependency stored in a FHS location, e.g. libstdc++.
-   * This is very common in Bazel workspaces, where downloaded binaries much
-   * likely doesn't support NixOS systems.
-   *
-   * ## Commands
-   *
-   * The function accepts an argument named `commands`, that can be used to
-   * define custom commands inside the shell, without having to mess with
-   * Nixpkgs' builders.
-   *
-   * The shell will always provide the `menu` command, that shows a menu
-   * with all the custom defined commands.
-   *
-   * ## Arguments
-   *
-   * The following arguments are accepted by this function:
-   *
-   * - `bubblewrap`: A boolean controlling if the shell will be bubblewrapped or not.
-   * - `commands`: An attribute set of form `<name> -> { command, help, category }`,
-   *   where each pair defines a custom command. The fields `help` and `category` are
-   *   used to build `menu`'s output.
-   * - `env`: An attribute set of form `<name> -> <value>` used to define custom environment
-   *   variables inside the shell.
-   * - `packages`: A _function_ that receives a Nixpkgs instance and returns the packages
-   *   to install inside the shell. This will be passed to `targetPkgs` option ofr
-   *   `buildFHSUserEnvBubblewrap`. Note that gcc is always present inside a bubblewrapped
-   *   shell.
-   * - `startup`: An attribute set which values will be executed at the start of the shell.
-   *   This is an attribute set to improve the readability of the startup code.
-   * - `bubblewrapOutsideNixOS`: A boolean controlling if we should enable bubblewrapping
-   *   outside of NixOS systems. Defaults to false, as non-NixOS system already have proper
-   *   FHS structure.
-   *
-   * Other than these, all of the remaining attributes are passed unchanged to the underlying
-   * shell function (be it `mkShell` or `buildFHSUserEnvBubblewrap`). This behavior is present
-   * to support situations where the interface provided here doesn't support certains use cases.
-   */
+  * A custom `mkShell` implementation that has suppor for easily defining
+  * custom commands and creating bubblewrapped FHS environments.
+  *
+  * ## Bubblewrapping
+  *
+  * If the argument `bubblewrap` is set to `true`, the shell will be created
+  * inside a bubblewrapped FHS environment (i.e. using Nixpkgs'
+  * buildFHSUserEnvBubblewrap). If value is `false` (or not present), the
+  * shell is created using `mkShell`.
+  *
+  * Having a bubblewrapped shell is useful if a dependency of the project
+  * needs some native dependency stored in a FHS location, e.g. libstdc++.
+  * This is very common in Bazel workspaces, where downloaded binaries much
+  * likely doesn't support NixOS systems.
+  *
+  * ## Commands
+  *
+  * The function accepts an argument named `commands`, that can be used to
+  * define custom commands inside the shell, without having to mess with
+  * Nixpkgs' builders.
+  *
+  * The shell will always provide the `menu` command, that shows a menu
+  * with all the custom defined commands.
+  *
+  * ## Arguments
+  *
+  * The following arguments are accepted by this function:
+  *
+  * - `bubblewrap`: A boolean controlling if the shell will be bubblewrapped or not.
+  * - `commands`: An attribute set of form `<name> -> { command, help, category }`,
+  *   where each pair defines a custom command. The fields `help` and `category` are
+  *   used to build `menu`'s output.
+  * - `env`: An attribute set of form `<name> -> <value>` used to define custom environment
+  *   variables inside the shell.
+  * - `packages`: A _function_ that receives a Nixpkgs instance and returns the packages
+  *   to install inside the shell. This will be passed to `targetPkgs` option ofr
+  *   `buildFHSUserEnvBubblewrap`. Note that gcc is always present inside a bubblewrapped
+  *   shell.
+  * - `startup`: An attribute set which values will be executed at the start of the shell.
+  *   This is an attribute set to improve the readability of the startup code.
+  * - `bubblewrapOutsideNixOS`: A boolean controlling if we should enable bubblewrapping
+  *   outside of NixOS systems. Defaults to false, as non-NixOS system already have proper
+  *   FHS structure.
+  *
+  * Other than these, all of the remaining attributes are passed unchanged to the underlying
+  * shell function (be it `mkShell` or `buildFHSUserEnvBubblewrap`). This behavior is present
+  * to support situations where the interface provided here doesn't support certains use cases.
+  */
   mkTmShell = let
     inherit (pkgs) writeShellScriptBin lib;
     inherit (lib) zipAttrsWithNames;
@@ -160,7 +159,7 @@
         (pkgs.buildFHSUserEnvBubblewrap (cleanArgs
           // {
             targetPkgs = pkgs: (packages pkgs) ++ map commandToBin commandsList;
-            multiPkgs = pkgs: with pkgs; [gcc];
+            multiPkgs = _: [];
             runScript = "bash --init-file ${bashEnv}";
             extraOutputsToInstall = ["dev"];
           }))

--- a/shell.nix
+++ b/shell.nix
@@ -1,11 +1,11 @@
 {
-  pkgs ? builtins.throw "Did you use `nix-shell`? This configuration uses flakes and only supports `nix develop`",
   lib ? null,
   startup ? {},
 }: let
   inherit (lib) mkTmShell;
 in
   mkTmShell {
+    bubblewrap = true;
     inherit startup;
 
     name = "tm-nixpkgs";


### PR DESCRIPTION
Now that Bazel uses an hermetic C/C++ toolchain, there is no need for
the shell to provide a C compiler.

I've no idea what happened to the formatting, but it is what alerandra does.