### PR TITLE
feat(shell): add startup helper command

### DIFF
--- a/lib/shell.nix
+++ b/lib/shell.nix
@@ -135,6 +135,10 @@
       bubblewrapOutsideNixOS ? false,
       ...
     } @ args: let
+      startupScript = pkgs.writeScriptBin "startup" ''
+        ${builtins.concatStringsSep "\n" (builtins.attrValues startup)}
+      '';
+
       cleanArgs = builtins.removeAttrs args ["env" "commands" "packages" "startup" "bubblewrap"];
       commandsList =
         (attrsToSubmodulesList commands)
@@ -149,11 +153,17 @@
             help = "prints this menu";
             category = "general commands";
           }
+          {
+            name = "startup";
+            command = "${startupScript}/bin/startup";
+            help = "re-run the shell startup process";
+            category = "general commands";
+          }
         ];
 
       bashEnv = pkgs.writeText "bash-env" ''
         ${builtins.concatStringsSep "\n" (builtins.attrValues (builtins.mapAttrs (n: v: "export ${n}=${v}") env))}
-        ${builtins.concatStringsSep "\n" (builtins.attrValues startup)}
+        ${startupScript}/bin/startup
 
         menu
 


### PR DESCRIPTION
Sometimes, I need to re-run the startup scripts of a shell. This normally happens when a database didn't startup correctly for some reason. As we don't have an easy way of doing this, I end up restarting the shell, which implies in closing my editor and losing important states, like Bazel analysis cache.

Although these cases indicate a bug somewhere in the startup process, I think it makes sense to give developers a way to re-run it to prevent blocking them on these types of issues.