### PR TITLE
feat(shell): run user shell after startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
             trusted-binary-caches = https://cache.nixos.org
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-      - run: "nix flake check"
+      - run: "nix flake check --impure"

--- a/flake.nix
+++ b/flake.nix
@@ -12,10 +12,10 @@
   };
 
   outputs = {
-    self,
     nixpkgs,
     flake-utils,
     pre-commit-hooks,
+    ...
   }: let
     forEachSystem = flake-utils.lib.eachSystem (with flake-utils.lib.system; [
       x86_64-linux

--- a/lib/shell.nix
+++ b/lib/shell.nix
@@ -14,7 +14,10 @@
     (attrsToList attrs);
 
   isNixOS = let
-    issue = builtins.readFile "/etc/issue";
+    issue =
+      if builtins.pathExists "/etc/issue"
+      then builtins.readFile "/etc/issue"
+      else "";
   in
     isLinux && (hasInfix "NixOS" issue);
 
@@ -120,6 +123,8 @@
         "\n[${category}]\n\n" + builtins.concatStringsSep "\n" (map opCmd cmd);
     in
       builtins.concatStringsSep "\n" (map opCat commandByCategoriesSorted) + "\n";
+
+    userShell = builtins.getEnv "SHELL";
   in
     {
       bubblewrap ? false,
@@ -147,12 +152,12 @@
         ];
 
       bashEnv = pkgs.writeText "bash-env" ''
-        export PS1='\033[0;31m[\u:\W]\033[0m '
-
         ${builtins.concatStringsSep "\n" (builtins.attrValues (builtins.mapAttrs (n: v: "export ${n}=${v}") env))}
         ${builtins.concatStringsSep "\n" (builtins.attrValues startup)}
 
         menu
+
+        exec ${userShell}
       '';
 
       bubbleWrappedShell =

--- a/templates/shellOnly/flake.nix
+++ b/templates/shellOnly/flake.nix
@@ -6,10 +6,7 @@
     tm-nixpkgs.url = "github:terramagna/nixpkgs";
   };
 
-  outputs = {
-    self,
-    tm-nixpkgs,
-  }:
+  outputs = {tm-nixpkgs, ...}:
     tm-nixpkgs.lib.forEachSystem (system: let
       tm-lib = tm-nixpkgs.lib.${system};
     in {


### PR DESCRIPTION
Our current implementation of `mkTmShell` leaves the user in a Bash session. Most of the time, we then run our shell or pass `--command="$SHELL"` to `nix develop`.

Given that everyone already does this, let's make the life easier by starting their shell automatically.