### PR TITLE
fix(startup-script): source it so that env vars are forwarded

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -35,9 +35,7 @@
     in
       sys: allPkgs.pkgs.${sys};
 
-    pre-commit-check-for = sys: let
-      pkgs = nixpkgsFor sys;
-    in
+    pre-commit-check-for = sys:
       pre-commit-hooks.lib.${sys}.run {
         src = ./.;
         hooks = {

--- a/lib/shell.nix
+++ b/lib/shell.nix
@@ -22,54 +22,54 @@
     isLinux && (hasInfix "NixOS" issue);
 
   /*
-  * A custom `mkShell` implementation that has suppor for easily defining
-  * custom commands and creating bubblewrapped FHS environments.
-  *
-  * ## Bubblewrapping
-  *
-  * If the argument `bubblewrap` is set to `true`, the shell will be created
-  * inside a bubblewrapped FHS environment (i.e. using Nixpkgs'
-  * buildFHSUserEnvBubblewrap). If value is `false` (or not present), the
-  * shell is created using `mkShell`.
-  *
-  * Having a bubblewrapped shell is useful if a dependency of the project
-  * needs some native dependency stored in a FHS location, e.g. libstdc++.
-  * This is very common in Bazel workspaces, where downloaded binaries much
-  * likely doesn't support NixOS systems.
-  *
-  * ## Commands
-  *
-  * The function accepts an argument named `commands`, that can be used to
-  * define custom commands inside the shell, without having to mess with
-  * Nixpkgs' builders.
-  *
-  * The shell will always provide the `menu` command, that shows a menu
-  * with all the custom defined commands.
-  *
-  * ## Arguments
-  *
-  * The following arguments are accepted by this function:
-  *
-  * - `bubblewrap`: A boolean controlling if the shell will be bubblewrapped or not.
-  * - `commands`: An attribute set of form `<name> -> { command, help, category }`,
-  *   where each pair defines a custom command. The fields `help` and `category` are
-  *   used to build `menu`'s output.
-  * - `env`: An attribute set of form `<name> -> <value>` used to define custom environment
-  *   variables inside the shell.
-  * - `packages`: A _function_ that receives a Nixpkgs instance and returns the packages
-  *   to install inside the shell. This will be passed to `targetPkgs` option ofr
-  *   `buildFHSUserEnvBubblewrap`. Note that gcc is always present inside a bubblewrapped
-  *   shell.
-  * - `startup`: An attribute set which values will be executed at the start of the shell.
-  *   This is an attribute set to improve the readability of the startup code.
-  * - `bubblewrapOutsideNixOS`: A boolean controlling if we should enable bubblewrapping
-  *   outside of NixOS systems. Defaults to false, as non-NixOS system already have proper
-  *   FHS structure.
-  *
-  * Other than these, all of the remaining attributes are passed unchanged to the underlying
-  * shell function (be it `mkShell` or `buildFHSUserEnvBubblewrap`). This behavior is present
-  * to support situations where the interface provided here doesn't support certains use cases.
-  */
+   * A custom `mkShell` implementation that has suppor for easily defining
+   * custom commands and creating bubblewrapped FHS environments.
+   *
+   * ## Bubblewrapping
+   *
+   * If the argument `bubblewrap` is set to `true`, the shell will be created
+   * inside a bubblewrapped FHS environment (i.e. using Nixpkgs'
+   * buildFHSUserEnvBubblewrap). If value is `false` (or not present), the
+   * shell is created using `mkShell`.
+   *
+   * Having a bubblewrapped shell is useful if a dependency of the project
+   * needs some native dependency stored in a FHS location, e.g. libstdc++.
+   * This is very common in Bazel workspaces, where downloaded binaries much
+   * likely doesn't support NixOS systems.
+   *
+   * ## Commands
+   *
+   * The function accepts an argument named `commands`, that can be used to
+   * define custom commands inside the shell, without having to mess with
+   * Nixpkgs' builders.
+   *
+   * The shell will always provide the `menu` command, that shows a menu
+   * with all the custom defined commands.
+   *
+   * ## Arguments
+   *
+   * The following arguments are accepted by this function:
+   *
+   * - `bubblewrap`: A boolean controlling if the shell will be bubblewrapped or not.
+   * - `commands`: An attribute set of form `<name> -> { command, help, category }`,
+   *   where each pair defines a custom command. The fields `help` and `category` are
+   *   used to build `menu`'s output.
+   * - `env`: An attribute set of form `<name> -> <value>` used to define custom environment
+   *   variables inside the shell.
+   * - `packages`: A _function_ that receives a Nixpkgs instance and returns the packages
+   *   to install inside the shell. This will be passed to `targetPkgs` option ofr
+   *   `buildFHSUserEnvBubblewrap`. Note that gcc is always present inside a bubblewrapped
+   *   shell.
+   * - `startup`: An attribute set which values will be executed at the start of the shell.
+   *   This is an attribute set to improve the readability of the startup code.
+   * - `bubblewrapOutsideNixOS`: A boolean controlling if we should enable bubblewrapping
+   *   outside of NixOS systems. Defaults to false, as non-NixOS system already have proper
+   *   FHS structure.
+   *
+   * Other than these, all of the remaining attributes are passed unchanged to the underlying
+   * shell function (be it `mkShell` or `buildFHSUserEnvBubblewrap`). This behavior is present
+   * to support situations where the interface provided here doesn't support certains use cases.
+   */
   mkTmShell = let
     inherit (pkgs) writeShellScriptBin lib;
     inherit (lib) zipAttrsWithNames;

--- a/lib/shell.nix
+++ b/lib/shell.nix
@@ -163,7 +163,7 @@
 
       bashEnv = pkgs.writeText "bash-env" ''
         ${builtins.concatStringsSep "\n" (builtins.attrValues (builtins.mapAttrs (n: v: "export ${n}=${v}") env))}
-        ${startupScript}/bin/startup
+        . ${startupScript}/bin/startup
 
         menu
 
@@ -183,7 +183,7 @@
       commonShell = pkgs.mkShell (cleanArgs
         // {
           packages = (packages pkgs) ++ map commandToBin commandsList;
-          shellHook = "source ${bashEnv}";
+          shellHook = ". ${bashEnv}";
         });
     in
       # Bubblewrapping outside NixOS cause problems if the user don't configure


### PR DESCRIPTION
Sources the startup script to that variables `export`ed by it are available in downstream shells.