### PR TITLE
fix(shell): require --impure on Linux when bubblewrap is enabled

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,6 +1,9 @@
 args: let
-  shell = import ./shell.nix args;
-in {
-  inherit (shell) mkTmShell;
-  inherit shell;
-}
+  invocation = import ./invocation.nix args;
+  shell = import ./shell.nix (args // {inherit lib;});
+  lib = {
+    inherit (shell) mkTmShell;
+    inherit shell invocation;
+  };
+in
+  lib

--- a/lib/invocation.nix
+++ b/lib/invocation.nix
@@ -1,0 +1,7 @@
+_: {
+  isInvocationImpure = let
+    # Build phase is always present inside a nix shell.
+    testEnv = builtins.getEnv "buildPhase";
+  in
+    testEnv != "";
+}


### PR DESCRIPTION
Given that multiple features require --impure and bubblewrap on NixOS doesn't work at all inside a pure environment, we should require linux users to pass --impure.